### PR TITLE
Fix atempo causing filter errors

### DIFF
--- a/config.json
+++ b/config.json
@@ -67,7 +67,7 @@
 		{
 			"text": "2.5x",
 			"video": "setpts=0.4*PTS",
-			"audio": "atempo=sqrt(2.5),atempo=sqrt(2.5)"
+			"audio": "atempo=2,atempo=1.25"
 		},
 		{
 			"text": "4x",

--- a/config.json
+++ b/config.json
@@ -67,7 +67,7 @@
 		{
 			"text": "2.5x",
 			"video": "setpts=0.4*PTS",
-			"audio": "atempo=1.25,atempo=1.25"
+			"audio": "atempo=sqrt(2.5),atempo=sqrt(2.5)"
 		},
 		{
 			"text": "4x",

--- a/config.json
+++ b/config.json
@@ -67,32 +67,32 @@
 		{
 			"text": "2.5x",
 			"video": "setpts=0.4*PTS",
-			"audio": "atempo=2.5"
+			"audio": "atempo=1.25,atempo=1.25"
 		},
 		{
 			"text": "4x",
 			"video": "setpts=0.25*PTS",
-			"audio": "atempo=4"
+			"audio": "atempo=2,atempo=2"
 		},
 		{
 			"text": "5x",
 			"video": "setpts=0.2*PTS",
-			"audio": "atempo=5"
+			"audio": "atempo=2,atempo=2,atempo=1.25"
 		},
 		{
 			"text": "8x",
 			"video": "setpts=0.125*PTS",
-			"audio": "atempo=8"
+			"audio": "atempo=2,atempo=2,atempo=2"
 		},
 		{
 			"text": "16x",
 			"video": "setpts=0.0625*PTS",
-			"audio": "atempo=16"
+			"audio": "atempo=2,atempo=2,atempo=2,atempo=2"
 		},
 		{
 			"text": "20x",
 			"video": "setpts=0.05*PTS",
-			"audio": "atempo=20"
+			"audio": "atempo=2,atempo=2,atempo=1.25,atempo=2,atempo=2"
 		},
 		{
 			"text": "remove"


### PR DESCRIPTION
atempo over 2 causes it to skip some samples. This causes some videos to fatally fail with a filtering error when skipping silence at speeds over 2x. By changing this to daisy-chained atempo values under 2, the samples will not be dropped and it will run without error. 

This may cause slightly longer runtime due to multiple passes, but is more resilient.